### PR TITLE
Fix README toolchain requirements to match the Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@
 
 - A PS3 running **Evilnat CFW** or **HEN** (CEX)
 - A **Jellyfin server** the console can reach (a local network is easiest)
-- To build it yourself: the **PSL1GHT toolchain** (`ppu-gcc` under
-  `/usr/local/ps3dev/`) and `sfo.xml` at `~/ps3dev/ps3py/sfo.xml`, which the
-  `.pkg` target uses
+- To build it yourself: the **ps3dev toolchain** (`ppu-gcc`, typically installed
+  under `/usr/local/ps3dev/`) plus a **PSL1GHT** SDK checkout. Export `PSL1GHT`
+  to point at the checkout and `PS3DEV` to your toolchain prefix — the `.pkg`
+  target needs `sfo.xml` from `$PS3DEV/bin/sfo.xml`
 
 ---
 
@@ -81,6 +82,9 @@ launch it through webMAN or multiMAN.
 ## Build from source
 
 ```bash
+export PSL1GHT=/path/to/PSL1GHT
+export PS3DEV=/usr/local/ps3dev
+
 make clean && make      # SELF only
 make pkg                # installable PKG
 ```


### PR DESCRIPTION
## Summary
- The README's Requirements section described a single "PSL1GHT toolchain" living under `/usr/local/ps3dev/`, but the `Makefile` actually requires two separate things: `PSL1GHT` (an SDK checkout, or the build errors out) and `PS3DEV` (the installed toolchain prefix holding `ppu-gcc`).
- The README's `sfo.xml` path (`~/ps3dev/ps3py/sfo.xml`) didn't match what the `Makefile` reads (`$(PS3DEV)/bin/sfo.xml`).
- Updated the Requirements bullet to describe both pieces accurately, and added the corresponding `export PSL1GHT=...` / `export PS3DEV=...` lines to the "Build from source" snippet.

## Test plan
- Docs-only change; no build/test needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HuX3EgLk57kyFCfwgH4E3g)_