### PR TITLE
Redesign the movie detail page: poster, cast, recommendations

### DIFF
--- a/source/api/api_detail.cpp
+++ b/source/api/api_detail.cpp
@@ -109,6 +109,43 @@ static void json_array_obj_names_join(const char *json, const char *array_key,
     }
 }
 
+// Walk the "People" array and fill arr with up to `max` credits (id + name +
+// role/job).  Jellyfin returns cast first, so the first N are the top billing.
+static void parse_people(const char *json, JFPerson *arr, int max, int *count) {
+    *count = 0;
+    const char *p = strstr(json, "\"People\":");
+    if (!p) return;
+    p += sizeof("\"People\":") - 1;
+    while (*p == ' ') p++;
+    if (*p != '[') return;
+    p++;
+    while (*p && *p != ']' && *count < max) {
+        while (*p && *p != '{' && *p != ']') p++;
+        if (!*p || *p == ']') break;
+        const char *obj_start = p;
+        int depth = 0; bool in_str = false, esc = false;
+        while (*p) {
+            char c = *p;
+            if (esc) { esc = false; }
+            else if (in_str) { if (c=='\\') esc=true; else if (c=='"') in_str=false; }
+            else { if (c=='"') in_str=true; else if (c=='{') depth++; else if (c=='}') { if (!--depth) { p++; break; } } }
+            p++;
+        }
+        int olen = (int)(p - obj_start);
+        JFPerson *person = &arr[*count];
+        person->id[0] = person->name[0] = person->role[0] = '\0';
+        json_get_in_range(obj_start, olen, "Name", person->name, sizeof(person->name));
+        json_get_in_range(obj_start, olen, "Id",   person->id,   sizeof(person->id));
+        char role[64] = "", type[24] = "";
+        json_get_in_range(obj_start, olen, "Role", role, sizeof(role));
+        json_get_in_range(obj_start, olen, "Type", type, sizeof(type));
+        // Actors carry a character in Role; crew carry only a job in Type.
+        if (role[0])      snprintf(person->role, sizeof(person->role), "%s", role);
+        else if (type[0]) snprintf(person->role, sizeof(person->role), "%s", type);
+        if (person->name[0]) (*count)++;
+    }
+}
+
 static void parse_media_streams(const char *json,
                                   char *video_out, int vlen,
                                   char *audio_out, int alen) {
@@ -328,6 +365,7 @@ bool jellyfin_fetch_item_detail(const char *item_id, XMBItemDetail *out) {
     json_array_first_string(resp,   "Taglines", out->tagline, sizeof(out->tagline));
     json_array_strings_join(resp,   "Genres",   out->genres,  sizeof(out->genres));
     json_array_obj_names_join(resp, "Studios",  out->studios, sizeof(out->studios));
+    parse_people(resp, out->people, JF_MAX_PEOPLE, &out->n_people);
 
     parse_media_streams(resp, out->video_info, sizeof(out->video_info),
                               out->audio_info, sizeof(out->audio_info));

--- a/source/api/jellyfin_api.h
+++ b/source/api/jellyfin_api.h
@@ -39,6 +39,14 @@ const char *jf_device_id(void);
 // the login screen instead of silently rendering an empty library.
 extern volatile bool g_auth_expired;
 
+// One credited person (cast/crew) for the detail page's Cast & Crew row.
+#define JF_MAX_PEOPLE 12
+typedef struct {
+    char id[64];      // person item id (for the headshot image)
+    char name[64];    // "Arnold Schwarzenegger"
+    char role[64];    // "as The Terminator" / "Director" (character or job)
+} JFPerson;
+
 // Full per-item detail (populated by jellyfin_fetch_item_detail)
 typedef struct {
     char overview[1024];       // Plot summary
@@ -50,6 +58,8 @@ typedef struct {
     char audio_info[128];      // "English EAC3 5.1"
     char genres[128];          // "Action, Crime, Thriller"
     char studios[256];         // "Universal Pictures, Original Film"
+    JFPerson people[JF_MAX_PEOPLE];  // top-billed cast + key crew
+    int      n_people;
 } XMBItemDetail;
 
 bool jellyfin_fetch_item_detail(const char *item_id, XMBItemDetail *out);

--- a/source/build_config.h
+++ b/source/build_config.h
@@ -25,4 +25,4 @@
 //  dev_hdd0/tmp/jellyfin_config.txt (keep the server URL on the LAN).
 // =========================================================================
 
-#define BUILD_FOR_RPCS3 1
+#define BUILD_FOR_RPCS3 0

--- a/source/cache/detail_media.cpp
+++ b/source/cache/detail_media.cpp
@@ -1,0 +1,137 @@
+// Detail-page hero art loader — see detail_media.h.
+//
+// This TU carries its OWN private copy of stb_image (STB_IMAGE_STATIC), on the
+// real heap.  The shared decoder in thumbnail_cache.cpp routes STBI_MALLOC
+// through img_arena, which is armed on the fetch THREAD; reusing it from the
+// main thread (where the detail overlay runs) would fight that arena.  A
+// file-local static copy sidesteps both the arena and any duplicate-symbol
+// clash with the shared implementation.
+
+#define STB_IMAGE_STATIC
+#define STB_IMAGE_IMPLEMENTATION
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
+#include "stb_image.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <malloc.h>
+
+#include "detail_media.h"
+#include "http.h"
+#include "jellyfin_api.h"   // g_server, g_token
+#include "plog.h"
+
+// A poster JPEG at ~90 quality is tens of KB; a 1280-wide backdrop lands
+// around 150-250KB.  512KB covers both with headroom.
+#define HERO_FETCH_MAX (512 * 1024)
+
+bool detail_media_load(const char *item_id, const char *image_type,
+                       int w, int h, float vbias, Bitmap *out) {
+    out->width = out->height = 0;
+    out->pixels = NULL;
+    out->offset = 0;
+    if (!item_id || !item_id[0] || !image_type || w <= 0 || h <= 0) return false;
+    if (!g_server[0]) return false;
+
+    uint8_t *buf = (uint8_t*)malloc(HERO_FETCH_MAX);
+    if (!buf) { plog("detail_media: no fetch buf"); return false; }
+
+    // Cap the SERVER-side resolution so the JPEG we decode stays small: a
+    // 1080p display asks for a 1920-wide backdrop, but the decode buffer for a
+    // full-size image (~8MB) is exactly the transient that starves the heap on
+    // real hardware.  Fetch at most FETCH_CAP_W wide (aspect-preserved) and
+    // nearest-scale UP to the on-screen w×h below — a darkened backdrop hides
+    // the softness, and a poster is never over the cap anyway.
+    const int FETCH_CAP_W = 960;
+    int fw = w, fh = h;
+    if (fw > FETCH_CAP_W) { fh = (int)((int64_t)fh * FETCH_CAP_W / fw); fw = FETCH_CAP_W; }
+
+    // fillWidth/fillHeight = scale + centre-crop to that box server-side, so a
+    // poster stays 2:3 and a backdrop is cropped to the strip we ask for.
+    char url[512];
+    snprintf(url, sizeof(url),
+        "%s/Items/%s/Images/%s?fillWidth=%d&fillHeight=%d&quality=90&format=Jpeg",
+        g_server, item_id, image_type, fw, fh);
+
+    int bytes = http_fetch_binary(url, g_token, buf, HERO_FETCH_MAX);
+    if (bytes <= 0) {
+        char m[96];
+        snprintf(m, sizeof(m), "detail_media: fetch %s fail (%d)", image_type, bytes);
+        plog(m);
+        free(buf);
+        return false;
+    }
+
+    int dw, dh, ch;
+    unsigned char *px = stbi_load_from_memory(buf, bytes, &dw, &dh, &ch, 4);
+    free(buf);
+    if (!px) {
+        char m[96];
+        snprintf(m, sizeof(m), "detail_media: decode %s fail", image_type);
+        plog(m);
+        return false;
+    }
+
+    u32 *dst = (u32*)memalign(16, (size_t)w * h * 4);
+    if (!dst) {
+        plog("detail_media: no pixel buf");
+        stbi_image_free(px);
+        return false;
+    }
+
+    // Aspect-preserving "cover" crop (like CSS object-fit: cover): scale the
+    // decoded image to fill w×h and centre-crop the overflow, so a 16:9
+    // backdrop forced into a wide banner box is never STRETCHED — only cropped.
+    // vbias picks the vertical crop window: 0=top, 0.5=centre, 1=bottom (a
+    // backdrop reads better biased toward the top, a poster centred).
+    int cw = dw, chh = dh, ox = 0, oy = 0;   // source crop rect
+    // Compare aspects with integer cross-multiplication (dw/dh vs w/h).
+    if ((int64_t)dw * h > (int64_t)w * dh) {
+        // Source is wider than target: crop width, full height.
+        cw = (int)((int64_t)dh * w / h);
+        ox = (dw - cw) / 2;
+    } else {
+        // Source is taller than target: crop height, full width.
+        chh = (int)((int64_t)dw * h / w);
+        oy = (int)((dh - chh) * vbias);
+    }
+    if (cw  < 1) cw  = 1;
+    if (chh < 1) chh = 1;
+
+    // Nearest-neighbour sample from the crop rect into the exact w×h output.
+    for (int y = 0; y < h; y++) {
+        int sy = oy + (int)((int64_t)y * chh / h);
+        const unsigned char *srow = px + (size_t)sy * dw * 4;
+        u32 *drow = dst + (size_t)y * w;
+        for (int x = 0; x < w; x++) {
+            int sx = ox + (int)((int64_t)x * cw / w);
+            const unsigned char *s = srow + (size_t)sx * 4;
+            drow[x] = ((u32)s[0] << 16) | ((u32)s[1] << 8) | s[2];
+        }
+    }
+    stbi_image_free(px);
+
+    out->width  = (u32)w;
+    out->height = (u32)h;
+    out->pixels = dst;
+    out->offset = 0;
+    char m[96];
+    snprintf(m, sizeof(m), "detail_media: %s ready %dx%d (src %dx%d)",
+             image_type, w, h, dw, dh);
+    plog(m);
+    return true;
+}
+
+void detail_media_free(Bitmap *out) {
+    if (out && out->pixels) { free(out->pixels); out->pixels = NULL; }
+    if (out) { out->width = out->height = 0; }
+}

--- a/source/cache/detail_media.h
+++ b/source/cache/detail_media.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "bitmap.h"
+
+// -------------------------------------------------------
+// Detail-page hero art (poster + backdrop)
+// -------------------------------------------------------
+// The grid thumbnail cache sizes every slot for a small library card
+// (~110x165) and silently DROPS anything bigger, so a detail-page poster
+// blown up from a card looks pixelated and there is nowhere to hold a wide
+// backdrop at all.  This loads ONE image at an arbitrary (larger) size into
+// its own main-memory Bitmap, synchronously.
+//
+// Blocking network + decode — call it once when the detail overlay opens
+// (off the render loop), not every frame.  On success out->pixels is a
+// malloc'd w*h ARGB buffer owned by the caller; free it with
+// detail_media_free().  On any failure out->pixels is NULL and the caller
+// falls back (cached card thumb for the poster, no backdrop otherwise).
+//
+// image_type is a Jellyfin image name: "Primary" (poster) or "Backdrop".
+// The art is "cover"-fit into w×h (scaled to fill, overflow cropped — never
+// stretched); vbias chooses the vertical crop window (0=top .. 1=bottom, 0.5
+// centre) for the axis that gets cropped.
+bool detail_media_load(const char *item_id, const char *image_type,
+                       int w, int h, float vbias, Bitmap *out);
+
+void detail_media_free(Bitmap *out);

--- a/source/ui/ui_internal.h
+++ b/source/ui/ui_internal.h
@@ -34,6 +34,7 @@ int  xmb_fetch_episodes(const char *series_id, const char *season_id,
                         int start_index, int *out_total);
 int  xmb_fetch_collection_items(const char *collection_id, XMBItem *arr,
                                 int max, int start_index, int *out_total);
+int  xmb_fetch_similar(const char *item_id, XMBItem *arr, int max);
 int  xmb_fetch_music_children(const char *id_param, const char *parent_id,
                               XMBItem *arr, int max, int *out_total);
 bool xmb_fetch_next_episode(const char *episode_id, XMBItem *out);

--- a/source/ui/ui_visuals.h
+++ b/source/ui/ui_visuals.h
@@ -285,6 +285,12 @@ void xmb_draw_letter_tile(const char *seed, const char *name,
 // 1:1 blit of a cached thumb at exactly w x h; false while still loading.
 bool xmb_cpu_blit_thumb(const char *item_id, int x, int y, int w, int h);
 
+// Scaled blit of an item's Primary poster (requested at the Movies-tab card
+// size, so the 2:3 aspect is preserved) into an arbitrary w x h rect; draws a
+// dim placeholder while the fetch is still in flight.  Used by the search list
+// and the triangle detail overlay's poster.
+void xmb_cpu_blit_thumb_scaled(const char *item_id, int x, int y, int w, int h);
+
 // Music sub-tab header row.  active = g_music_subtab; focused = the d-pad
 // is on the header (active label pops white instead of just underlined).
 void xmb_draw_music_subtabs(int x, int y, int active, bool focused);

--- a/source/ui/xmb/ui_fetch.cpp
+++ b/source/ui/xmb/ui_fetch.cpp
@@ -260,6 +260,19 @@ int xmb_fetch_collection_items(const char *collection_id, XMBItem *arr, int max,
     return n;
 }
 
+// "More Like This" for the detail page: GET /Items/{id}/Similar → up to `max`
+// recommended items, parsed like any library row (poster + name + meta).
+int xmb_fetch_similar(const char *item_id, XMBItem *arr, int max) {
+    char url[512];
+    snprintf(url, sizeof(url),
+        "%s/Items/%s/Similar?userId=%s&limit=%d"
+        "&Fields=Genres,RunTimeTicks,ProductionYear",
+        g_server, item_id, g_userid, max);
+    int status = http_request(0, url, NULL, g_token, responseBuffer, RESPONSE_SIZE);
+    if (status != 200) return 0;
+    return parse_xmb_items(responseBuffer, arr, max);
+}
+
 // -------------------------------------------------------
 // Sliding-window pagination helpers
 // -------------------------------------------------------

--- a/source/ui/xmb/ui_info.cpp
+++ b/source/ui/xmb/ui_info.cpp
@@ -13,8 +13,71 @@
 #include "rsxutil.h"
 #include "timing.h"
 #include "plog.h"
+#include "slog.h"
+#include "detail_media.h"
+#include "thumbnail_cache.h"
 
-void xmb_show_item_info(const XMBItem *it) {
+// The title band behind the header — a deep purple stripe over the backdrop
+// (the official page's grey bar, re-tinted to fit the XMB indigo palette).
+#define XMB_DETAIL_BAND 0x00412C73UL
+
+// "More Like This" recommendations to request/show.
+#define INFO_SIMILAR_MAX 12
+
+
+// Draw text at (x,y), truncated with ".." to max_w px.  y is a signed screen
+// coordinate (the page scrolls), so a line above the top is simply culled by
+// drawTTF's own clipping.
+static void info_clip_text(int x, int y, const char *text, float px,
+                           u32 color, int max_w, bool bold) {
+    if (!text || !text[0]) return;
+    if (ttf_text_width(text, px, bold) <= max_w) {
+        drawTTF((u32)x, (u32)y, text, px, color, bold);
+        return;
+    }
+    char buf[160];
+    snprintf(buf, sizeof(buf), "%s", text);
+    int len = (int)strlen(buf);
+    while (len > 1) {
+        buf[--len] = '\0';
+        char trial[164];
+        snprintf(trial, sizeof(trial), "%s..", buf);
+        if (ttf_text_width(trial, px, bold) <= max_w) {
+            drawTTF((u32)x, (u32)y, trial, px, color, bold);
+            return;
+        }
+    }
+}
+
+// A frame that bails out early — switching titles, or coming back from the
+// player — must STILL queue a flip before looping.  waitflip() at the top of
+// the next iteration spins until the PREVIOUS flip lands
+// (`while (gcmGetFlipStatus() != 0) usleep(50);`), so a `continue` that skips
+// flip() leaves the status stuck at "pending" and hangs the UI thread forever
+// at 20k syscalls/sec.  This is the same rsxSync()+flip() the screen does on
+// entry; call it immediately before any early `continue`.
+static void info_skip_frame(void) { rsxSync(); flip(); }
+
+// 1:1 CPU blit of a main-memory bitmap to the current framebuffer, clipped to
+// the display.  Same idea as the grid's card blit (ui_lists.cpp) — call after
+// rsxSync.  The pixels are precomputed, so this is a per-row memcpy into
+// write-combined VRAM (fast on hardware); no per-pixel blend/read.
+static void info_blit(const Bitmap *bm, int dx, int dy) {
+    if (!bm || !bm->pixels) return;
+    int w = (int)bm->width, h = (int)bm->height;
+    for (int row = 0; row < h; row++) {
+        int sy = dy + row;
+        if (sy < 0 || sy >= (int)display_height) continue;
+        int sx0 = dx, cw = w, srcx = 0;
+        if (sx0 < 0) { srcx = -sx0; cw += sx0; sx0 = 0; }
+        if (sx0 + cw > (int)display_width) cw = (int)display_width - sx0;
+        if (cw <= 0) continue;
+        memcpy(color_buffer[curr_fb] + (u32)sy * display_width + sx0,
+               bm->pixels + (u32)row * bm->width + srcx, (size_t)cw * 4);
+    }
+}
+
+void xmb_show_item_info(const XMBItem *root) {
     {
         char dbg[260];
         snprintf(dbg, sizeof(dbg),
@@ -23,60 +86,188 @@ void xmb_show_item_info(const XMBItem *it) {
             "name='%.40s'",
             btn_cur.triangle, btn_cur.circle, btn_cur.cross,
             btn_prev.triangle, btn_prev.circle, btn_prev.cross,
-            it->name);
+            root->name);
         plog(dbg);
     }
     rsxSync();
     flip();
     init_btns();
-    {
-        char dbg[200];
-        snprintf(dbg, sizeof(dbg),
-            "info: after init_btns btn_cur(tri=%d cir=%d crs=%d) "
-            "btn_prev(tri=%d cir=%d crs=%d)",
-            btn_cur.triangle, btn_cur.circle, btn_cur.cross,
-            btn_prev.triangle, btn_prev.circle, btn_prev.cross);
-        plog(dbg);
-    }
+
+    // ---- The title currently on screen.  Opening a "More Like This" pick
+    // REPLACES it in place: Circle always leaves for the library grid, so there
+    // is no back-trail worth keeping and only one title's detail + ~550KB
+    // poster is ever resident (this screen used to re-enter itself recursively,
+    // holding every visited title's page state and poster at once).
+    XMBItem cur_item = *root;
+    int nav_hops = 0;   // drill-ins so far — STATE log / test assertions only
+
+    // ---- Layout, computed once (poster + text column geometry) ----
+    const int X   = XMB_ITEM_PAD;
+    const int top = XMB_OY + XMB_TOPBAR_H + 12;
+    const int content_bot = (int)display_height - XMB_BOTTOM_PAD;
+    int poster_h = content_bot - top;
+    if (poster_h > 456) poster_h = 456;
+    const int poster_w = poster_h * 2 / 3;
+    const int poster_x = X, poster_y = top;
+    const int tx    = poster_x + poster_w + 28;   // text column left edge
+    const int max_w = (int)display_width - tx - X;
+    const int back_w = (int)display_width;
+    const int band_y0 = top - 14;                 // purple title-band extent
+    const int band_y1 = top + 96;
+    const int view_bottom = content_bot;
+    const int SIM_CH = 222;                       // More Like This card height
+
+    // ---- Per-title state, (re)loaded whenever the nav stack moves ----
     XMBItemDetail detail;
     memset(&detail, 0, sizeof(detail));
-    jellyfin_fetch_item_detail(it->id, &detail);
+    Bitmap hero_poster;
+    memset(&hero_poster, 0, sizeof(hero_poster));
+    XMBItem similar[INFO_SIMILAR_MAX];
+    int  n_similar = 0;
+    bool reload    = true;
+
+    // The page is taller than the screen; d-pad up/down jumps to top/bottom.
+    // max_scroll is recomputed from the laid-out content height each frame.
+    int scroll_y = 0, max_scroll = 0;
+    // Focus moves between the Play button and the More Like This row, which is
+    // what Cross acts on.  (Gating this on "is the row visible" made Cross mean
+    // Open even at the top of the page, so Play could never be pressed.)
+    enum { FOCUS_PLAY = 0, FOCUS_SIM = 1 };
+    int focus = FOCUS_PLAY;
+    int sim_sel = 0, sim_row_scroll = 0;
+
     int info_frames = 0;
     int info_exit_reason = 0;
     bool exit_armed = false;
     while (running) {
+        if (reload) {
+            reload = false;
+            const XMBItem *cur = &cur_item;
+            detail_media_free(&hero_poster);
+            memset(&detail, 0, sizeof(detail));
+            jellyfin_fetch_item_detail(cur->id, &detail);
+            // Hi-res poster: the grid thumbnail cache only holds card-sized art,
+            // so a poster blown up from it looks pixelated.  On failure the draw
+            // loop falls back to the cached card thumb.
+            detail_media_load(cur->id, "Primary", poster_w, poster_h, 0.5f,
+                              &hero_poster);
+            n_similar = xmb_fetch_similar(cur->id, similar, INFO_SIMILAR_MAX);
+            // Cast headshots + similar posters are card-sized: let the grid
+            // cache reuse its slots for them (ticked each frame below).
+            thumb_cache_retarget();
+            scroll_y = 0; max_scroll = 0;
+            sim_sel  = 0; sim_row_scroll = 0;
+            focus    = FOCUS_PLAY;
+            exit_armed = false;
+            init_btns();
+            slog_state("INFO_OPEN depth=%d item_id=%s name=%.40s",
+                       nav_hops, cur->id, cur->name);
+        }
+        const XMBItem *it = &cur_item;
+
         waitflip();
         sysUtilCheckCallback();
         poll_buttons();
+
         if (!exit_armed) {
-            if (!btn_cur.circle && !btn_cur.triangle)
+            if (!btn_cur.circle && !btn_cur.triangle && !btn_cur.cross)
                 exit_armed = true;
         } else {
-            if (BTN_PRESSED(circle))   { info_exit_reason = 1; goto info_done; }
+            // Circle always leaves the screen for the library grid — including
+            // from a title reached through More Like This.
+            if (BTN_PRESSED(circle)) { info_exit_reason = 1; goto info_done; }
             if (BTN_PRESSED(triangle)) { info_exit_reason = 2; goto info_done; }
+
+            // Up/down move focus AND jump the page: down drops from the Play
+            // button to the recommendations at the bottom, up returns to Play
+            // at the top — one press each way.
+            if (BTN_PRESSED(down)) {
+                if (focus == FOCUS_PLAY && n_similar > 0) focus = FOCUS_SIM;
+                scroll_y = max_scroll;
+            }
+            if (BTN_PRESSED(up)) {
+                if (focus == FOCUS_SIM) focus = FOCUS_PLAY;
+                scroll_y = 0;
+            }
+            if (focus == FOCUS_SIM) {
+                if (BTN_REPEAT(left)  && sim_sel > 0)             sim_sel--;
+                if (BTN_REPEAT(right) && sim_sel < n_similar - 1) sim_sel++;
+            }
+            if (BTN_PRESSED(cross)) {
+                if (focus == FOCUS_SIM) {
+                    // Swap the page over to the highlighted recommendation.
+                    // Copied by value first — the reload overwrites similar[].
+                    cur_item = similar[sim_sel];
+                    nav_hops++;
+                    reload = true;
+                    info_skip_frame();
+                    continue;
+                } else {
+                    // Play — same launch flow as the grid (resume prompt first).
+                    int resume = xmb_resume_choice(it);
+                    if (resume >= 0) {
+                        if (strcmp(it->type, "Episode") == 0)
+                            xmb_play_episode_with_next(it, (u32)resume);
+                        else
+                            xmb_play_item(it, (u32)resume);
+                    }
+                    exit_armed = false;
+                    init_btns();
+                    info_skip_frame();
+                    continue;
+                }
+            }
         }
+        if (scroll_y < 0)          scroll_y = 0;
+        if (scroll_y > max_scroll) scroll_y = max_scroll;
+
+        thumb_cache_tick();
         clearScreen(XMB_BG);
         wave_draw();
         rsxSync();
         {
-            int X = XMB_ITEM_PAD;
-            int Y = XMB_OY + XMB_TOPBAR_H + 12;
-            int max_w = (int)display_width - 2 * X;
+            // Everything below is drawn in SCREEN space = layout position
+            // minus scroll_y, so the whole page scrolls as one.
+            const int py = poster_y - scroll_y;
 
-            // Title, truncated to the content width.
+            // ---- Purple title band behind the header (over the wave).
+            drawRect(0, (u32)(band_y0 - scroll_y), (u32)back_w,
+                     (u32)(band_y1 - band_y0), XMB_DETAIL_BAND);
+
+            // ---- Left column: portrait poster.  Hi-res if it loaded, else the
+            // cached card thumb upscaled (dim placeholder while it fetches).
+            if (hero_poster.pixels)
+                info_blit(&hero_poster, poster_x, py);
+            else
+                xmb_cpu_blit_thumb_scaled(it->id, poster_x, py,
+                                          poster_w, poster_h);
+            // Hairline frame just outside the artwork.
+            drawRect((u32)(poster_x - 1), (u32)(py - 1),
+                     (u32)(poster_w + 2), 1, XMB_HAIRLINE);
+            drawRect((u32)(poster_x - 1), (u32)(py + poster_h),
+                     (u32)(poster_w + 2), 1, XMB_HAIRLINE);
+            drawRect((u32)(poster_x - 1), (u32)(py - 1),
+                     1, (u32)(poster_h + 2), XMB_HAIRLINE);
+            drawRect((u32)(poster_x + poster_w), (u32)(py - 1),
+                     1, (u32)(poster_h + 2), XMB_HAIRLINE);
+
+            // ---- Right column: title + metadata + text, to the poster's right.
+            int Y = top - scroll_y;
+
+            // Title, truncated to the text-column width.
             {
                 char tbuf[132];
                 snprintf(tbuf, sizeof(tbuf), "%s", it->name);
                 int len = (int)strlen(tbuf);
                 while (len > 1 && ttf_text_width(tbuf, 40) > max_w)
                     tbuf[--len] = '\0';
-                drawTTF((u32)X, (u32)Y, tbuf, 40, XMB_WHITE, true);
+                drawTTF((u32)tx, (u32)Y, tbuf, 40, XMB_WHITE, true);
             }
             Y += 62;
 
             // Meta row: year · duration, official-rating chip, ★ rating.
             {
-                int mx = X;
+                int mx = tx;
                 char meta[64] = "";
                 if (it->year_str[0])
                     snprintf(meta, sizeof(meta), "%s", it->year_str);
@@ -108,8 +299,30 @@ void xmb_show_item_info(const XMBItem *it) {
             }
             Y += 44;
 
+            // Play button — Cross launches playback (with the resume prompt if
+            // the title is partly watched), matching the grid's launch flow.
+            // Focused by default; a white frame shows when Cross will play.
+            {
+                const int bw = 128, bh = 40;
+                const bool pf = (focus == FOCUS_PLAY);
+                drawRect((u32)tx, (u32)Y, (u32)bw, (u32)bh,
+                         pf ? XMB_ACCENT : XMB_PANEL_HI);
+                if (pf) {
+                    drawRect((u32)(tx - 2), (u32)(Y - 2), (u32)(bw + 4), 2, XMB_KEY_SEL);
+                    drawRect((u32)(tx - 2), (u32)(Y + bh), (u32)(bw + 4), 2, XMB_KEY_SEL);
+                    drawRect((u32)(tx - 2), (u32)(Y - 2), 2, (u32)(bh + 4), XMB_KEY_SEL);
+                    drawRect((u32)(tx + bw), (u32)(Y - 2), 2, (u32)(bh + 4), XMB_KEY_SEL);
+                }
+                u32 fg = pf ? 0x00131630UL : XMB_TEXT_DIM;
+                drawIcon((u32)(tx + 16), (u32)(Y + (bh - 22) / 2), ICON_PLAY,
+                         22.0f, fg);
+                drawTTF((u32)(tx + 46), (u32)(Y + (bh - 20) / 2 + 1), "Play",
+                        20, fg, true);
+                Y += bh + 18;
+            }
+
             if (detail.tagline[0]) {
-                drawTTF((u32)X, (u32)Y, detail.tagline, 20, 0x00AFA3E8UL);
+                drawTTF((u32)tx, (u32)Y, detail.tagline, 20, 0x00AFA3E8UL);
                 Y += 38;
             }
 
@@ -138,7 +351,7 @@ void xmb_show_item_info(const XMBItem *it) {
                              : (last_sp > 0 ? last_sp : fit);
                     if (take <= 0) take = 1;
                     snprintf(buf, sizeof(buf), "%.*s", take, p);
-                    drawTTF((u32)X, (u32)Y, buf, 19, 0x00C9CEE4UL);
+                    drawTTF((u32)tx, (u32)Y, buf, 19, 0x00C9CEE4UL);
                     p += take;
                     while (*p == ' ') p++;
                     Y += 30;
@@ -156,15 +369,96 @@ void xmb_show_item_info(const XMBItem *it) {
             };
             for (int i = 0; i < 4; i++) {
                 if (!facts[i].value[0]) continue;
-                drawTTF((u32)X,         (u32)(Y + 2), facts[i].label, 15,
+                drawTTF((u32)tx,         (u32)(Y + 2), facts[i].label, 15,
                         XMB_TEXT_FAINT);
-                drawTTF((u32)(X + 120), (u32)Y, facts[i].value, 17, XMB_TEXT);
+                drawTTF((u32)(tx + 120), (u32)Y, facts[i].value, 17, XMB_TEXT);
                 Y += 32;
+            }
+
+            // ---- Sections below the hero: begin under whichever column is
+            // taller — the fact list or the poster.
+            int hero_bottom = poster_y + poster_h - scroll_y;
+            int sec = (Y > hero_bottom ? Y : hero_bottom) + 40;
+
+            // Cast & Crew — headshot cards with name + role.
+            if (detail.n_people > 0) {
+                drawTTF((u32)X, (u32)sec, "Cast & Crew", 22, XMB_TEXT, true);
+                sec += 42;
+                const int cw = 118, ch = 176, gap = 22;
+                for (int i = 0; i < detail.n_people; i++) {
+                    int cxp = X + i * (cw + gap);
+                    if (cxp + cw > (int)display_width - X) break;   // no h-scroll yet
+                    xmb_cpu_blit_thumb_scaled(detail.people[i].id, cxp, sec, cw, ch);
+                    info_clip_text(cxp, sec + ch + 8, detail.people[i].name,
+                                   14, XMB_TEXT, cw, true);
+                    if (detail.people[i].role[0])
+                        info_clip_text(cxp, sec + ch + 28, detail.people[i].role,
+                                       12, XMB_TEXT_DIM, cw, false);
+                }
+                sec += ch + 8 + 44;
+            }
+
+            // More Like This — recommended poster cards.  Left/right selects a
+            // card (Cross opens it); the row scrolls horizontally to follow.
+            if (n_similar > 0) {
+                drawTTF((u32)X, (u32)sec, "More Like This", 22, XMB_TEXT, true);
+                sec += 42;
+                const int cw = 148, ch = SIM_CH, gap = 22;
+                const int pitch = cw + gap;
+                const int window_w = (int)display_width - 2 * X;
+                // Keep the selected card within the visible window.
+                int sel_left = sim_sel * pitch;
+                if (sel_left < sim_row_scroll) sim_row_scroll = sel_left;
+                if (sel_left + cw > sim_row_scroll + window_w)
+                    sim_row_scroll = sel_left + cw - window_w;
+                int max_row = n_similar * pitch - gap - window_w;
+                if (max_row < 0) max_row = 0;
+                if (sim_row_scroll < 0)       sim_row_scroll = 0;
+                if (sim_row_scroll > max_row) sim_row_scroll = max_row;
+
+                for (int i = 0; i < n_similar; i++) {
+                    int cxp = X + i * pitch - sim_row_scroll;
+                    if (cxp + cw <= 0 || cxp >= (int)display_width) continue;
+                    xmb_cpu_blit_thumb_scaled(similar[i].id, cxp, sec, cw, ch);
+                    bool selected = (i == sim_sel && focus == FOCUS_SIM);
+                    if (selected) {
+                        drawRect((u32)(cxp - 2), (u32)(sec - 2), (u32)(cw + 4), 2, XMB_KEY_SEL);
+                        drawRect((u32)(cxp - 2), (u32)(sec + ch),  (u32)(cw + 4), 2, XMB_KEY_SEL);
+                        drawRect((u32)(cxp - 2), (u32)(sec - 2), 2, (u32)(ch + 4), XMB_KEY_SEL);
+                        drawRect((u32)(cxp + cw), (u32)(sec - 2), 2, (u32)(ch + 4), XMB_KEY_SEL);
+                    }
+                    info_clip_text(cxp, sec + ch + 8, similar[i].name, 14,
+                                   selected ? XMB_WHITE : XMB_TEXT_DIM, cw,
+                                   selected);
+                }
+                sec += ch + 8 + 30;
+            }
+
+            // Content height (absolute) → how far the page can scroll.
+            int content_bottom = sec + scroll_y;
+            max_scroll = content_bottom - view_bottom;
+            if (max_scroll < 0) max_scroll = 0;
+
+            // Scrollbar on the right edge when the page overflows.
+            if (max_scroll > 0) {
+                int bx = (int)display_width - 10;
+                int ty0 = top, th = view_bottom - top;
+                drawRect((u32)bx, (u32)ty0, 3, (u32)th, XMB_TRACK);
+                int total = content_bottom > 0 ? content_bottom : 1;
+                int thb = th * view_bottom / total;
+                if (thb < 26) thb = 26;
+                if (thb > th) thb = th;
+                int off = (th - thb) * scroll_y / max_scroll;
+                drawRect((u32)bx, (u32)(ty0 + off), 3, (u32)thb, XMB_ACCENT);
             }
         }
         {
-            static const Hint h[] = {{'C',"Back"}};
-            draw_hints_bar(h, 1);
+            Hint h[3]; int nh = 0;
+            h[nh].glyph = 'C'; h[nh].label = "Back";  nh++;
+            if (max_scroll > 0) { h[nh].glyph = 'D'; h[nh].label = "Scroll"; nh++; }
+            h[nh].glyph = 'X';
+            h[nh].label = (focus == FOCUS_SIM) ? "Open" : "Play"; nh++;
+            draw_hints_bar(h, nh);
         }
         flip();
         info_frames++;
@@ -172,6 +466,7 @@ void xmb_show_item_info(const XMBItem *it) {
             char dbg[80];
             snprintf(dbg, sizeof(dbg), "info: frame=%d", info_frames);
             plog(dbg);
+            slog_state("INFO_FRAME n=%d", info_frames);   // liveness heartbeat
         }
     }
     info_exit_reason = 3;
@@ -186,6 +481,8 @@ void xmb_show_item_info(const XMBItem *it) {
             btn_prev.triangle, btn_prev.circle, btn_prev.cross);
         plog(dbg);
     }
+    slog_state("INFO_CLOSE reason=%d frames=%d", info_exit_reason, info_frames);
+    detail_media_free(&hero_poster);
     g_info_cooldown_until = timing_get_us() + 500000;
     init_btns();
 }


### PR DESCRIPTION
Reworks the triangle detail overlay to follow the official Jellyfin movie page while keeping the XMB look:

- Two-column layout with a hi-res poster. The grid thumbnail cache only holds card-sized art, so a detail poster blown up from it looked pixelated; cache/detail_media.{h,cpp} loads one image at display size with an aspect-preserving cover crop (never stretched). The server-side fetch is capped at 960px wide so the decode transient cannot starve the heap on real hardware.
- A purple title band behind the header.
- Cast & Crew row, from the item's People (api_detail.cpp).
- More Like This row, from /Items/{id}/Similar (ui_fetch.cpp). Left/right select a pick and Cross swaps the page over to it in place; Circle always leaves for the library grid, so only one title's detail and poster are ever resident.
- A Play button on Cross, using the same resume/launch flow as the grid. D-pad up/down move focus between the Play button and the recommendations, jumping to either end of the page in one press.

Also fixes a UI-thread hang reachable from this screen: waitflip() spins until the PREVIOUS flip lands, so any early `continue` that skipped flip() left gcmGetFlipStatus() pending forever and the thread burned 20k usleep syscalls/sec. Every early-exit path now queues a flip first.

BUILD_FOR_RPCS3 returns to 0 for hardware. The STATE breadcrumbs added for the RPCS3 test harness are gated behind it and compile out -- verified: no STATE strings in the hardware ELF.